### PR TITLE
Create first version of the plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / organization := "com.alejandrohdezma"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-addCommandAlias("ci-test", "fix --check; mdoc; publishLocal; scripted; test")
+addCommandAlias("ci-test", "fix --check; mdoc; scripted")
 addCommandAlias("ci-docs", "mdoc; headerCreateAll")
 
 skip in publish := true

--- a/sbt-remove-test-from-pom/src/main/scala/com/alejandrohdezma/sbt/remove/test/from/pom/RemoveTestFromPomPlugin.scala
+++ b/sbt-remove-test-from-pom/src/main/scala/com/alejandrohdezma/sbt/remove/test/from/pom/RemoveTestFromPomPlugin.scala
@@ -1,0 +1,62 @@
+package com.alejandrohdezma.sbt.remove.test.from.pom
+
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+import scala.xml.{Elem, Node, NodeSeq}
+
+import sbt.Keys.{pomPostProcess, publishArtifact, sLog}
+import sbt.plugins.JvmPlugin
+import sbt.{AutoPlugin, Def, Plugins, Test}
+
+/**
+ * This plugin automatically removes test dependencies from POMs for projects that
+ * have `publishArtifact in Test` set to `false`.
+ */
+object RemoveTestFromPomPlugin extends AutoPlugin {
+
+  override def requires: Plugins = JvmPlugin
+
+  override def trigger = allRequirements
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    pomPostProcess := transformNode {
+      case TestDependency(dependency) if !publishArtifact.in(Test).value =>
+        sLog.value.warn(s"Test dependency $dependency has been omitted by $label")
+        EmptyNodeSeq
+    }
+  )
+
+  @SuppressWarnings(Array("scalafix:DisableSyntax.=="))
+  private object TestDependency {
+
+    def isTestDependency(elem: Elem): Boolean =
+      elem.label == "dependency" &&
+        elem.child.exists(child => child.label == "scope" && child.text == "test")
+
+    def unapply(arg: Node): Option[String] = arg match {
+      case e: Elem if isTestDependency(e) =>
+        val organization = e.child.find(_.label == "groupId").map(_.text).mkString
+        val artifact     = e.child.find(_.label == "artifactId").map(_.text).mkString
+        val version      = e.child.find(_.label == "version").map(_.text).mkString
+
+        Some(s"$organization:$artifact:$version")
+      case _ => None
+    }
+
+  }
+
+  private def transformNode(p: PartialFunction[Node, NodeSeq]): Node => Node = { node =>
+    val rule = new RewriteRule {
+      override def transform(n: Node): Seq[Node] =
+        if (p.isDefinedAt(n)) p(n) else n
+    }
+
+    val transformer = new RuleTransformer(rule)
+
+    transformer.transform(node).head /* scalafix:ok */
+  }
+
+  private object EmptyNodeSeq extends NodeSeq {
+    override def theSeq: Seq[Node] = Seq()
+  }
+
+}

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/build.sbt
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/build.sbt
@@ -1,0 +1,8 @@
+libraryDependencies += "org.specs2" %% "specs2-core" % "4.9.2" % Test
+
+//To ensure local proxies are not included
+pomIncludeRepository := (_ => false)
+
+publishArtifact in Test := true
+
+TaskKey[Unit]("makePomInBaseDirectory") := makePom.value.renameTo(baseDirectory.value / "gen.pom")

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/project/plugins.sbt
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.alejandrohdezma" % "sbt-remove-test-from-pom" % x)
+  case _       => sys.error("https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html")
+}

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/test
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/test
@@ -1,0 +1,3 @@
+# this test ensures test dependencies are included if `publishArtifact in test := false`
+> makePomInBaseDirectory
+$ must-mirror gen.pom test.pom

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/test.pom
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/include-dependencies/test.pom
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default</groupId>
+    <artifactId>include-dependencies_2.12</artifactId>
+    <packaging>jar</packaging>
+    <description>include-dependencies</description>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>include-dependencies</name>
+    <organization>
+        <name>default</name>
+    </organization>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.12.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_2.12</artifactId>
+            <version>4.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/build.sbt
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/build.sbt
@@ -1,0 +1,6 @@
+libraryDependencies += "org.specs2" %% "specs2-core" % "4.9.2" % Test
+
+//To ensure local proxies are not included
+pomIncludeRepository := (_ => false)
+
+TaskKey[Unit]("makePomInBaseDirectory") := makePom.value.renameTo(baseDirectory.value / "gen.pom")

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/project/plugins.sbt
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.alejandrohdezma" % "sbt-remove-test-from-pom" % x)
+  case _       => sys.error("https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html")
+}

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/test
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/test
@@ -1,0 +1,3 @@
+# this test ensures test dependencies are removed if `publishArtifact in test := false`
+> makePomInBaseDirectory
+$ must-mirror gen.pom test.pom

--- a/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/test.pom
+++ b/sbt-remove-test-from-pom/src/sbt-test/sbt-remove-test-from-pom/simple/test.pom
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>default</groupId>
+    <artifactId>simple_2.12</artifactId>
+    <packaging>jar</packaging>
+    <description>simple</description>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>simple</name>
+    <organization>
+        <name>default</name>
+    </organization>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.12.10</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Removes test dependencies from POM for those projects that have set `publishArtifact in test := false` (which is the default configuration).